### PR TITLE
Add minimal `uv run` dependencies info

### DIFF
--- a/schemas/validate-all-families.py
+++ b/schemas/validate-all-families.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+#
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+# "fastjsonschema",
+# ]
+# ///
+
 import sys
 from os import listdir
 from os.path import isfile, join


### PR DESCRIPTION
Afterwards, the script can be invoked with:
```bash
uv run schemas/validate-all-families.py
```
(and dependencies are automatically pulled)

Possible further improvement:
```diff
- #!/usr/bin/env python3
+ #!/usr/bin/env -S uv run --script
```
...maybe for later.