### PR TITLE
Remove empty "Size" for tools

### DIFF
--- a/tools/corpus-query-tools/aconcorde.json
+++ b/tools/corpus-query-tools/aconcorde.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "No licence",
-      "Size": [],
       "Platform": ["Platform-independent (java)"],
       "Infrastructure": "CLARIN",
       "Access": {

--- a/tools/corpus-query-tools/antconc.json
+++ b/tools/corpus-query-tools/antconc.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "<a href=\"https://www.laurenceanthony.net/software/antconc/releases/AntConc4011/license.pdf\">Proprietary</a>",
-      "Size": [],
       "Platform": ["Linux", "MacOS", "Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/antpconc.json
+++ b/tools/corpus-query-tools/antpconc.json
@@ -6,7 +6,6 @@
       "Functionality": ["Parallel Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": ["Linux", "MacOS", "Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/autosearch.json
+++ b/tools/corpus-query-tools/autosearch.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing", "corpus upload and analysis"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIAH-NL",
       "Access": {

--- a/tools/corpus-query-tools/bncweb-lancaster.json
+++ b/tools/corpus-query-tools/bncweb-lancaster.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["eng"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-UK",
       "Access": {

--- a/tools/corpus-query-tools/casualconc.json
+++ b/tools/corpus-query-tools/casualconc.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "No licence",
-      "Size": [],
       "Platform": ["MacOS"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/catma.json
+++ b/tools/corpus-query-tools/catma.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing", "corpus upload and analysis"],
       "Language": ["deu"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/chn.json
+++ b/tools/corpus-query-tools/chn.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["nld"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/cintil-treebank-searcher.json
+++ b/tools/corpus-query-tools/cintil-treebank-searcher.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["por"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "PORTULAN",
       "Access": {

--- a/tools/corpus-query-tools/cintil.json
+++ b/tools/corpus-query-tools/cintil.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["por"],
       "Licence": "<a href=\"https://portulanclarin.net/workbench/license/\">Proprietary</a>",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "PORTULAN CLARIN",
       "Access": {

--- a/tools/corpus-query-tools/clan.json
+++ b/tools/corpus-query-tools/clan.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "GPL2 (source code)",
-      "Size": [],
       "Platform": ["Windows", "MacOS", "Source code provided for Linux users"],
       "Infrastructure": "TalkBank",
       "Access": {

--- a/tools/corpus-query-tools/clark.json
+++ b/tools/corpus-query-tools/clark.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying", "corpus building"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": ["Platform-independent"],
       "Infrastructure": "CLARIN-BG",
       "Access": {

--- a/tools/corpus-query-tools/clic.json
+++ b/tools/corpus-query-tools/clic.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["eng"],
       "Licence": "Use of CLiC follows the University of Birmingham’s legal policy",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-UK",
       "Access": {

--- a/tools/corpus-query-tools/coanzse.json
+++ b/tools/corpus-query-tools/coanzse.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["eng"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/collocate.json
+++ b/tools/corpus-query-tools/collocate.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "No licence",
-      "Size": [],
       "Platform": ["Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/compleat.json
+++ b/tools/corpus-query-tools/compleat.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing", "corpus upload and analysis"],
       "Language": ["eng", "fra"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/concgram.json
+++ b/tools/corpus-query-tools/concgram.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/concordancer-espanol.json
+++ b/tools/corpus-query-tools/concordancer-espanol.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["spa"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/concordancer-estonian.json
+++ b/tools/corpus-query-tools/concordancer-estonian.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["est"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CELR",
       "Access": {

--- a/tools/corpus-query-tools/concordancer-gysseling.json
+++ b/tools/corpus-query-tools/concordancer-gysseling.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["nld"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIAH-NL",
       "Access": {

--- a/tools/corpus-query-tools/concordancer-hr-nat-corp.json
+++ b/tools/corpus-query-tools/concordancer-hr-nat-corp.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["hrv"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-HR",
       "Access": {

--- a/tools/corpus-query-tools/concordancer-italian-heritage.json
+++ b/tools/corpus-query-tools/concordancer-italian-heritage.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing (non-parallel and parallel)"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-IT",
       "Access": {

--- a/tools/corpus-query-tools/concordancer-middelnederlands.json
+++ b/tools/corpus-query-tools/concordancer-middelnederlands.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["nld"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIAH-NL",
       "Access": {

--- a/tools/corpus-query-tools/concordancer-portuguese.json
+++ b/tools/corpus-query-tools/concordancer-portuguese.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["por"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/coquery.json
+++ b/tools/corpus-query-tools/coquery.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "GPL3",
-      "Size": [],
       "Platform": ["Linux", "MacOS", "Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/corpkit.json
+++ b/tools/corpus-query-tools/corpkit.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "No licence",
-      "Size": [],
       "Platform": ["OSX"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/corpus-explorer.json
+++ b/tools/corpus-query-tools/corpus-explorer.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying", "text and data mining"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": ["Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/corpus-presenter.json
+++ b/tools/corpus-query-tools/corpus-presenter.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying", "corpus compilation"],
       "Language": ["Language independent"],
       "Licence": "No licence",
-      "Size": [],
       "Platform": ["Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/corpus-workbench.json
+++ b/tools/corpus-query-tools/corpus-workbench.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "GPL3",
-      "Size": [],
       "Platform": ["Linux", "MacOS", "VM images (CQPwebinABox)"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/corpuscle.json
+++ b/tools/corpus-query-tools/corpuscle.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARINO",
       "Access": {

--- a/tools/corpus-query-tools/cosmas-ii.json
+++ b/tools/corpus-query-tools/cosmas-ii.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["deu"],
       "Licence": "DeReKo-EULA",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-D",
       "Access": {

--- a/tools/corpus-query-tools/couranten.json
+++ b/tools/corpus-query-tools/couranten.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["Dutch (17th Century)"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIAH-NL",
       "Access": {

--- a/tools/corpus-query-tools/cqpweb-lancaster.json
+++ b/tools/corpus-query-tools/cqpweb-lancaster.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["eng", "ara", "fra", "ita", "nor", "pol", "lav"],
       "Licence": "No licence",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-UK",
       "Access": {

--- a/tools/corpus-query-tools/dwds.json
+++ b/tools/corpus-query-tools/dwds.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["deu"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-D",
       "Access": {

--- a/tools/corpus-query-tools/english-corpora.json
+++ b/tools/corpus-query-tools/english-corpora.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["eng"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/exakt.json
+++ b/tools/corpus-query-tools/exakt.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": ["Windows", "MacOS", "Linux with a current Java runtime environment."],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/gate.json
+++ b/tools/corpus-query-tools/gate.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "GNU",
-      "Size": [],
       "Platform": ["Platform-independent (Windows and generic installers available)"],
       "Infrastructure": "CLARIN-UK",
       "Access": {

--- a/tools/corpus-query-tools/glossa.json
+++ b/tools/corpus-query-tools/glossa.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing and text analysis"],
       "Language": ["Language independent"],
       "Licence": "Public license for software. CLARIN-licenses for corpora in Glossa",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARINO Text Laboratory Centre",
       "Access": {

--- a/tools/corpus-query-tools/gretel.json
+++ b/tools/corpus-query-tools/gretel.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing (treebanks)"],
       "Language": ["nld"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIAH-NL",
       "Access": {

--- a/tools/corpus-query-tools/i-analyzer.json
+++ b/tools/corpus-query-tools/i-analyzer.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing", "analysis", "visualizations"],
       "Language": ["Multiple"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/icecup.json
+++ b/tools/corpus-query-tools/icecup.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "<a href=\"https://www.ucl.ac.uk/english-usage/projects/ice-gb/iceorder2.htm\">Proprietary</a>",
-      "Size": [],
       "Platform": ["Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/iness.json
+++ b/tools/corpus-query-tools/iness.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing (treebanks)"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARINO",
       "Access": {

--- a/tools/corpus-query-tools/intellitext.json
+++ b/tools/corpus-query-tools/intellitext.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing", "corpus upload"],
       "Language": ["ara", "ces", "zho", "eng", "fra", "deu", "ita", "jpn", "kan", "lit", "por", "rus", "spa", "ukr"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-UK",
       "Access": {

--- a/tools/corpus-query-tools/kontext-clarin-si.json
+++ b/tools/corpus-query-tools/kontext-clarin-si.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["sqi", "eus", "bos", "bul", "cat", "hrv", "ces", "dan", "nld", "eng", "est", "fin", "fra", "Gaelic", "glg", "ger", "ell", "hun", "isl", "ita", "jpn", "lav", "lit", "mkd", "cnr", "nor", "pol", "por", "ron", "rus", "srp", "hbs", "slk", "slv", "spa", "swe", "tur", "ukr"],
       "Licence": "No licence",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN.SI",
       "Access": {

--- a/tools/corpus-query-tools/kontext-latvian.json
+++ b/tools/corpus-query-tools/kontext-latvian.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["lav"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-LV",
       "Access": {

--- a/tools/corpus-query-tools/kontext-lindat.json
+++ b/tools/corpus-query-tools/kontext-lindat.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["ces"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIAH-CZ",
       "Access": {

--- a/tools/corpus-query-tools/korap-corola.json
+++ b/tools/corpus-query-tools/korap-corola.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["ron"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/korap-dereko.json
+++ b/tools/corpus-query-tools/korap-dereko.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["deu"],
       "Licence": "DeReKo-EULA",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-D",
       "Access": {

--- a/tools/corpus-query-tools/korp-copenhagen.json
+++ b/tools/corpus-query-tools/korp-copenhagen.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["dan"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-DK",
       "Access": {

--- a/tools/corpus-query-tools/korp-kielipankki.json
+++ b/tools/corpus-query-tools/korp-kielipankki.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["fin", "swe", "rus", "eng", "and more"],
       "Licence": "Individual corpora have different licenses (and access conditions)",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "PORTULAN CLARIN",
       "Access": {

--- a/tools/corpus-query-tools/korp-sprakbanken.json
+++ b/tools/corpus-query-tools/korp-sprakbanken.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["swe"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "SWE-CLARIN",
       "Access": {

--- a/tools/corpus-query-tools/lancsbox.json
+++ b/tools/corpus-query-tools/lancsbox.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "CC BY-NC-ND 4.0",
-      "Size": [],
       "Platform": ["Platform-independent (java)"],
       "Infrastructure": "CLARIN-UK",
       "Access": {

--- a/tools/corpus-query-tools/liwc-22.json
+++ b/tools/corpus-query-tools/liwc-22.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "<a href=\"https://www.liwc.app/help/eula\">Proprietary</a>",
-      "Size": [],
       "Platform": ["Windows", "MacOS"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/lncc.json
+++ b/tools/corpus-query-tools/lncc.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["lav", "ltg", "lit"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-LV",
       "Access": {

--- a/tools/corpus-query-tools/monoconc.json
+++ b/tools/corpus-query-tools/monoconc.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "No licence",
-      "Size": [],
       "Platform": ["Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/nat-pol-ipi-pan.json
+++ b/tools/corpus-query-tools/nat-pol-ipi-pan.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["pol"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/nat-pol-pelcra.json
+++ b/tools/corpus-query-tools/nat-pol-pelcra.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["pol"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/nb-dh-lab.json
+++ b/tools/corpus-query-tools/nb-dh-lab.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing/analysis"],
       "Language": ["nob", "nno", "sme", "smj", "sma"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARINO",
       "Access": {

--- a/tools/corpus-query-tools/nederlab.json
+++ b/tools/corpus-query-tools/nederlab.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["nld"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIAH-NL",
       "Access": {

--- a/tools/corpus-query-tools/nooj.json
+++ b/tools/corpus-query-tools/nooj.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "GPL Academic - Non-commercial (Java version)",
-      "Size": [],
       "Platform": ["Windows (cut-down java version also available for other OS)"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/nosketch-clarin-si.json
+++ b/tools/corpus-query-tools/nosketch-clarin-si.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["sqi", "eus", "bos", "bul", "cat", "hrv", "ces", "dan", "nld", "eng", "est", "fin", "fra", "Gaelic", "glg", "ger", "ell", "hun", "isl", "ita", "jpn", "lav", "lit", "mkd", "cnr", "nor", "pol", "por", "ron", "rus", "srp", "hbs", "slk", "slv", "spa", "swe", "tur", "ukr"],
       "Licence": "no",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN.SI",
       "Access": {

--- a/tools/corpus-query-tools/nosketch-engine.json
+++ b/tools/corpus-query-tools/nosketch-engine.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "Components available under separate licences: GPLv2+, GPLv3",
-      "Size": [],
       "Platform": ["Linux"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/nvivo.json
+++ b/tools/corpus-query-tools/nvivo.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "<a href=\"https://www.qsrinternational.com/legal-and-compliance/end-user-license-agreement-qsr-software-services\">Proprietary</a>",
-      "Size": [],
       "Platform": ["Windows", "MacOS"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/opensonar.json
+++ b/tools/corpus-query-tools/opensonar.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["nld"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIAH-NL",
       "Access": {

--- a/tools/corpus-query-tools/paqu.json
+++ b/tools/corpus-query-tools/paqu.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing (treebanks)"],
       "Language": ["nld"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/paraconc.json
+++ b/tools/corpus-query-tools/paraconc.json
@@ -6,7 +6,6 @@
       "Functionality": ["Parallel Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "No licence",
-      "Size": [],
       "Platform": ["Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/praaline.json
+++ b/tools/corpus-query-tools/praaline.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying", "corpus building"],
       "Language": ["Language independent"],
       "Licence": "GPL3",
-      "Size": [],
       "Platform": ["Linux", "MacOS", "Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/prime-machine.json
+++ b/tools/corpus-query-tools/prime-machine.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "<a href=\"https://www.theprimemachine.net/files/End-User-License-Agreement-tPMv3.pdf\">Proprietary</a>",
-      "Size": [],
       "Platform": ["iOS", "MacOS", "Android", "Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/pyxmlconc.json
+++ b/tools/corpus-query-tools/pyxmlconc.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "MIT",
-      "Size": [],
       "Platform": ["Platform-independent (requires Python)"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/qcat.json
+++ b/tools/corpus-query-tools/qcat.json
@@ -6,7 +6,6 @@
       "Functionality": ["Annotating/concordancing/querying/listening to audio recordings"],
       "Language": ["Language independent"],
       "Licence": "Apache License 2.0",
-      "Size": [],
       "Platform": [".NET"],
       "Infrastructure": "CLARIN.SI",
       "Access": {

--- a/tools/corpus-query-tools/scattertext.json
+++ b/tools/corpus-query-tools/scattertext.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/shebanq.json
+++ b/tools/corpus-query-tools/shebanq.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["heb"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIAH-NL",
       "Access": {

--- a/tools/corpus-query-tools/shinyconc.json
+++ b/tools/corpus-query-tools/shinyconc.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying", "corpus building"],
       "Language": ["Language independent"],
       "Licence": "GPL3",
-      "Size": [],
       "Platform": ["Windows", "MacOS", "Linux"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/simple-concordancer.json
+++ b/tools/corpus-query-tools/simple-concordancer.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "<a href=\"http://www.textworld.com/scp/copyrigh.txt\">Proprietary</a>",
-      "Size": [],
       "Platform": ["Linux", "MacOS", "Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/simple-corpus-tool.json
+++ b/tools/corpus-query-tools/simple-corpus-tool.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": ["Linux", "MacOS", "Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/skell.json
+++ b/tools/corpus-query-tools/skell.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["eng", "rus", "deu", "ita", "ces", "est"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/sketchengine.json
+++ b/tools/corpus-query-tools/sketchengine.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing", "corpus upload and processing"],
       "Language": ["Multiple"],
       "Licence": "<a href=\"https://www.sketchengine.eu/terms-of-use/\">Proprietary</a>",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/spaadia.json
+++ b/tools/corpus-query-tools/spaadia.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": ["Windows", "MacOS"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/teitok.json
+++ b/tools/corpus-query-tools/teitok.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing, corpus upload and processing"],
       "Language": ["Multiple"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIAH-CZ",
       "Access": {

--- a/tools/corpus-query-tools/textable.json
+++ b/tools/corpus-query-tools/textable.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "GPL3",
-      "Size": [],
       "Platform": ["Linux", "MacOS", "Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/textal.json
+++ b/tools/corpus-query-tools/textal.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": ["iPhone app"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/textstat.json
+++ b/tools/corpus-query-tools/textstat.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": ["Versions for Windows and platform-independent Python version"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/tsakorpus.json
+++ b/tools/corpus-query-tools/tsakorpus.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["Language independent"],
       "Licence": "MIT License",
-      "Size": [],
       "Platform": ["Ubuntu", "Windows"],
       "Infrastructure": "Non-CLARIN",
       "Access": {

--- a/tools/corpus-query-tools/txm-online.json
+++ b/tools/corpus-query-tools/txm-online.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["fra", "eng"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/txm.json
+++ b/tools/corpus-query-tools/txm.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "GPL2",
-      "Size": [],
       "Platform": ["Linux", "MacOS", "Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/voyant-tools-dk.json
+++ b/tools/corpus-query-tools/voyant-tools-dk.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing", "Stylometry"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-DK",
       "Access": {

--- a/tools/corpus-query-tools/voyant-tools-salidar.json
+++ b/tools/corpus-query-tools/voyant-tools-salidar.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing", "Stylometry"],
       "Language": ["ara", "bos", "hrv", "ces", "eng", "fra", "deu", "heb", "ita", "jpn", "por", "srp", "spa"],
       "Licence": "GPL3 (code)",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "SADiLAR",
       "Access": {

--- a/tools/corpus-query-tools/voyant-tools.json
+++ b/tools/corpus-query-tools/voyant-tools.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing", "Stylometry"],
       "Language": ["ara", "bos", "hrv", "ces", "eng", "fra", "deu", "heb", "ita", "jpn", "por", "rus", "srp", "spa"],
       "Licence": "GPL3 (code)",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/webclark.json
+++ b/tools/corpus-query-tools/webclark.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["bul"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-BG",
       "Access": {

--- a/tools/corpus-query-tools/webcorp-learn.json
+++ b/tools/corpus-query-tools/webcorp-learn.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/webcorp-lse.json
+++ b/tools/corpus-query-tools/webcorp-lse.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/webcorp.json
+++ b/tools/corpus-query-tools/webcorp.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/wmatrix.json
+++ b/tools/corpus-query-tools/wmatrix.json
@@ -6,7 +6,6 @@
       "Functionality": ["Querying/concordancing", "corpus upload and processing"],
       "Language": ["eng", "spa"],
       "Licence": "",
-      "Size": [],
       "Platform": [],
       "Infrastructure": "CLARIN-UK",
       "Access": {

--- a/tools/corpus-query-tools/word-cruncher.json
+++ b/tools/corpus-query-tools/word-cruncher.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "",
-      "Size": [],
       "Platform": ["Windows", "iOS"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/wordless.json
+++ b/tools/corpus-query-tools/wordless.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "GPL3",
-      "Size": [],
       "Platform": ["Windows", "MacOS", "Linux"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/wordsmith-tools.json
+++ b/tools/corpus-query-tools/wordsmith-tools.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "<a href=\"https://lexically.net/wordsmith/version7/user_licence.txt\">Proprietary</a>",
-      "Size": [],
       "Platform": ["Windows"],
       "Infrastructure": "External",
       "Access": {

--- a/tools/corpus-query-tools/wordstatix.json
+++ b/tools/corpus-query-tools/wordstatix.json
@@ -6,7 +6,6 @@
       "Functionality": ["Concordancing/querying"],
       "Language": ["Language independent"],
       "Licence": "GPL3",
-      "Size": [],
       "Platform": ["Linux", "Windows"],
       "Infrastructure": "External",
       "Access": {


### PR DESCRIPTION
Tools don't have "Size": (in any traditional sense). Here, we use:
```bash
sed -i '/"Size": \[\]/d' *
```
to delete the entry for all tools.